### PR TITLE
Updated admin turning method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,11 +172,14 @@ GEM
     nio4r (2.7.0)
     nokogiri (1.16.0-x64-mingw-ucrt)
       racc (~> 1.4)
+    nokogiri (1.16.0-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
+    pg (1.5.4)
     pg (1.5.4-x64-mingw-ucrt)
     psych (5.1.2)
       stringio
@@ -322,6 +325,7 @@ GEM
 
 PLATFORMS
   x64-mingw-ucrt
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -10,20 +10,10 @@ class MembersController < ApplicationController
     }
   end
 
-  # def verify
-  #   user = gt_user_from_token
-  #   if user
-  #     user.update(role: 'admin')
-  #     render json: { message: 'Successfully verified your user' }, status: :ok
-  #   else
-  #     render json: { message: 'Incorrect token or unauthorized user' }, status: :unauthorized
-  #   end
-  # end
-
   def update_role
     user = gt_user_from_token
     if user.role == 'admin'
-      user_update = User.find(params[:email])
+      user_update = User.find_by(email: params[:email])
       user_update.update(role: 'admin')
       render json: { message: 'Successfully updated user role' }, status: :ok
     else

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,6 +1,6 @@
 class MembersController < ApplicationController
   before_action :authenticate_user!
-  skip_before_action :authenticate_user!, only: :verify
+  skip_before_action :authenticate_user!, only: :update_role
 
   def show
     user = gt_user_from_token
@@ -10,13 +10,24 @@ class MembersController < ApplicationController
     }
   end
 
-  def verify
+  # def verify
+  #   user = gt_user_from_token
+  #   if user
+  #     user.update(role: 'admin')
+  #     render json: { message: 'Successfully verified your user' }, status: :ok
+  #   else
+  #     render json: { message: 'Incorrect token or unauthorized user' }, status: :unauthorized
+  #   end
+  # end
+
+  def update_role
     user = gt_user_from_token
-    if user
-      user.update(role: 'admin')
-      render json: { message: 'Successfully verified your user' }, status: :ok
+    if user.role == 'admin'
+      user_update = User.find(params[:email])
+      user_update.update(role: 'admin')
+      render json: { message: 'Successfully updated user role' }, status: :ok
     else
-      render json: { message: 'Incorrect token or unauthorized user' }, status: :unauthorized
+      render json: { message: 'Unauthorized user' }, status: :unauthorized
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
   }
   get '/member-data', to: 'members#show'
 
-  post '/verify', to: 'members#verify'
+  # post '/verify', to: 'members#verify'
+
+  post '/update', to: 'members#update_role'
 
   mount Rswag::Ui::Engine => '/api-docs'
   mount Rswag::Api::Engine => '/api-docs'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,6 @@ Rails.application.routes.draw do
   }
   get '/member-data', to: 'members#show'
 
-  # post '/verify', to: 'members#verify'
-
   post '/update', to: 'members#update_role'
 
   mount Rswag::Ui::Engine => '/api-docs'


### PR DESCRIPTION
Removed `verify` method and opted out for a new method called `update_role` to handle the update of a user to become admin.